### PR TITLE
Factory setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "node": ">=8.9"
   },
   "dependencies": {
+    "@types/lodash": "^4.14.122",
     "@types/luxon": "^1.11.1",
+    "lodash": "^4.17.11",
     "luxon": "^1.11.4",
     "mobx": "^5.9.0",
     "mobx-state-tree": "^3.10.2"

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-console
 import test from 'ava';
 import {
+  calculateMoments,
   dataStoreFactory,
   generateParamsArrayFromInferObject,
   getKeysArray,
@@ -17,6 +18,18 @@ const INSTANCE_TYPES: InferObject = {
   b: 'categorical',
   c: 'continuous'
 };
+
+test('inferObject', t => {
+  const defaultMoments = generateParamsArrayFromInferObject(INSTANCE_TYPES);
+
+  const EXPECTED_DEFAULT_MOMENTS: MomentsObject = {
+    a: { min: null, max: null, sum: 0 },
+    b: { frequencies: {} },
+    c: { min: null, max: null, sum: 0 }
+  };
+
+  t.deepEqual(EXPECTED_DEFAULT_MOMENTS, defaultMoments);
+});
 
 test('dataStore', t => {
   const keysArray = getKeysArray(FIRST_SAMPLE_DATA);
@@ -34,6 +47,13 @@ test('dataStore', t => {
     // 'dataStore'
   );
 
+  const moments = calculateMoments(filledSample, INSTANCE_TYPES);
+  const EXPECTED_MOMENTS: MomentsObject = {
+    a: { min: 2, max: 3, sum: 5 },
+    b: { frequencies: { mamma: 1, papà: 1 } },
+    c: { min: 2, max: 2, sum: 2 }
+  };
+
   // Keys array tests
   t.notThrows(() => getKeysArray(FIRST_SAMPLE_DATA));
   t.deepEqual(EXPECTED_KEYS_ARRAY, keysArray);
@@ -42,17 +62,10 @@ test('dataStore', t => {
   t.notThrows(() => populateNullData(FIRST_SAMPLE_DATA, keysArray));
   t.deepEqual(EXPECTED_FILLED_SAMPLE, filledSample);
 
+  // Moments test
+  t.notThrows(() => calculateMoments(filledSample, INSTANCE_TYPES));
+  t.deepEqual(EXPECTED_MOMENTS, moments);
+
   t.notThrows(() => dataStoreFactory(FIRST_SAMPLE_DATA));
   t.not(result, null);
-});
-
-test('inferObject', t => {
-  const defualtInfer = generateParamsArrayFromInferObject(INSTANCE_TYPES);
-  const EXPECTED_INFER_DEFAULT = [
-    { min: 0, max: 0, mean: 0 },
-    { frequencies: [] },
-    { min: 0, max: 0, mean: 0 }
-  ];
-
-  // t.deepEqual(EXPECTED_INFER_DEFAULT, defualtInfer);
 });

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -1,5 +1,4 @@
 // tslint:disable:no-expression-statement
-// tslint:disable:no-console
 import test from 'ava';
 import {
   calculateMoments,
@@ -41,7 +40,12 @@ test('dataStore', t => {
     { a: 2, b: 'papà', c: 2 }
   ];
 
-  const Store = dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES);
+  const Store = dataStoreFactory(
+    'hello',
+    FIRST_SAMPLE_DATA,
+    INSTANCE_TYPES
+  ) as { a: number[]; toJSON: () => unknown }; // Better typing for this
+  const a = Store.a;
 
   const moments = calculateMoments(filledSample, INSTANCE_TYPES);
   const EXPECTED_MOMENTS: MomentsObject = {
@@ -65,5 +69,5 @@ test('dataStore', t => {
   t.notThrows(() =>
     dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES)
   );
-  t.not(Store, null);
+  t.deepEqual(a, [3, 2]);
 });

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -1,10 +1,10 @@
 // tslint:disable:no-expression-statement
+// tslint:disable:no-console
 import test from 'ava';
-import { types } from 'mobx-state-tree';
-import { dataStoreFactory } from './datastore';
+import { dataStoreFactory, getKeysArray, populateNullData } from './datastore';
 
-test('power', t => {
-  const FIRST_SAMPLE_DATA: ReadonlyArray<any> = [
+test('dataStore', t => {
+  const FIRST_SAMPLE_DATA: GenericDatum[] = [
     { a: 3, b: 'mamma' },
     { a: 2, b: 'papà', c: 2 }
   ];
@@ -14,15 +14,31 @@ test('power', t => {
     c: 'continuous'
   };
 
+  const keysArray = getKeysArray(FIRST_SAMPLE_DATA);
+  const EXPECTED_KEYS_ARRAY = ['a', 'b', 'c'];
+
+  const filledSample = populateNullData(FIRST_SAMPLE_DATA);
+  const EXPECTED_FILLED_SAMPLE = [
+    { a: 3, b: 'mamma', c: null },
+    { a: 2, b: 'papà', c: 2 }
+  ];
+
   const result = dataStoreFactory(
     FIRST_SAMPLE_DATA,
     INSTANCE_TYPES,
     'dataStore'
   );
 
+  // Keys array tests
+  t.notThrows(() => getKeysArray(FIRST_SAMPLE_DATA));
+  t.deepEqual(EXPECTED_KEYS_ARRAY, keysArray);
+
+  // Filled array tests
+  t.notThrows(() => populateNullData(FIRST_SAMPLE_DATA));
+  t.deepEqual(EXPECTED_FILLED_SAMPLE, filledSample);
+
   t.notThrows(() =>
     dataStoreFactory(FIRST_SAMPLE_DATA, INSTANCE_TYPES, 'dataStore')
   );
   t.not(result, null);
-  t.is(typeof result, typeof types.model());
 });

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -41,11 +41,7 @@ test('dataStore', t => {
     { a: 2, b: 'papà', c: 2 }
   ];
 
-  const result = dataStoreFactory(
-    FIRST_SAMPLE_DATA
-    // INSTANCE_TYPES,
-    // 'dataStore'
-  );
+  const result = dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES);
 
   const moments = calculateMoments(filledSample, INSTANCE_TYPES);
   const EXPECTED_MOMENTS: MomentsObject = {
@@ -66,6 +62,8 @@ test('dataStore', t => {
   t.notThrows(() => calculateMoments(filledSample, INSTANCE_TYPES));
   t.deepEqual(EXPECTED_MOMENTS, moments);
 
-  t.notThrows(() => dataStoreFactory(FIRST_SAMPLE_DATA));
+  t.notThrows(() =>
+    dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES)
+  );
   t.not(result, null);
 });

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -41,7 +41,7 @@ test('dataStore', t => {
     { a: 2, b: 'papà', c: 2 }
   ];
 
-  const result = dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES);
+  const Store = dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES);
 
   const moments = calculateMoments(filledSample, INSTANCE_TYPES);
   const EXPECTED_MOMENTS: MomentsObject = {
@@ -65,5 +65,5 @@ test('dataStore', t => {
   t.notThrows(() =>
     dataStoreFactory('hello', FIRST_SAMPLE_DATA, INSTANCE_TYPES)
   );
-  t.not(result, null);
+  t.not(Store, null);
 });

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -54,5 +54,5 @@ test('inferObject', t => {
     { min: 0, max: 0, mean: 0 }
   ];
 
-  t.deepEqual(EXPECTED_INFER_DEFAULT, defualtInfer);
+  // t.deepEqual(EXPECTED_INFER_DEFAULT, defualtInfer);
 });

--- a/src/lib/datastore.spec.ts
+++ b/src/lib/datastore.spec.ts
@@ -1,32 +1,37 @@
 // tslint:disable:no-expression-statement
 // tslint:disable:no-console
 import test from 'ava';
-import { dataStoreFactory, getKeysArray, populateNullData } from './datastore';
+import {
+  dataStoreFactory,
+  generateParamsArrayFromInferObject,
+  getKeysArray,
+  populateNullData
+} from './datastore';
+
+const FIRST_SAMPLE_DATA: GenericDatum[] = [
+  { a: 3, b: 'mamma' },
+  { a: 2, b: 'papà', c: 2 }
+];
+const INSTANCE_TYPES: InferObject = {
+  a: 'continuous',
+  b: 'categorical',
+  c: 'continuous'
+};
 
 test('dataStore', t => {
-  const FIRST_SAMPLE_DATA: GenericDatum[] = [
-    { a: 3, b: 'mamma' },
-    { a: 2, b: 'papà', c: 2 }
-  ];
-  const INSTANCE_TYPES: InferObject = {
-    a: 'continuous',
-    b: 'categorical',
-    c: 'continuous'
-  };
-
   const keysArray = getKeysArray(FIRST_SAMPLE_DATA);
   const EXPECTED_KEYS_ARRAY = ['a', 'b', 'c'];
 
-  const filledSample = populateNullData(FIRST_SAMPLE_DATA);
+  const filledSample = populateNullData(FIRST_SAMPLE_DATA, keysArray);
   const EXPECTED_FILLED_SAMPLE = [
     { a: 3, b: 'mamma', c: null },
     { a: 2, b: 'papà', c: 2 }
   ];
 
   const result = dataStoreFactory(
-    FIRST_SAMPLE_DATA,
-    INSTANCE_TYPES,
-    'dataStore'
+    FIRST_SAMPLE_DATA
+    // INSTANCE_TYPES,
+    // 'dataStore'
   );
 
   // Keys array tests
@@ -34,11 +39,20 @@ test('dataStore', t => {
   t.deepEqual(EXPECTED_KEYS_ARRAY, keysArray);
 
   // Filled array tests
-  t.notThrows(() => populateNullData(FIRST_SAMPLE_DATA));
+  t.notThrows(() => populateNullData(FIRST_SAMPLE_DATA, keysArray));
   t.deepEqual(EXPECTED_FILLED_SAMPLE, filledSample);
 
-  t.notThrows(() =>
-    dataStoreFactory(FIRST_SAMPLE_DATA, INSTANCE_TYPES, 'dataStore')
-  );
+  t.notThrows(() => dataStoreFactory(FIRST_SAMPLE_DATA));
   t.not(result, null);
+});
+
+test('inferObject', t => {
+  const defualtInfer = generateParamsArrayFromInferObject(INSTANCE_TYPES);
+  const EXPECTED_INFER_DEFAULT = [
+    { min: 0, max: 0, mean: 0 },
+    { frequencies: [] },
+    { min: 0, max: 0, mean: 0 }
+  ];
+
+  t.deepEqual(EXPECTED_INFER_DEFAULT, defualtInfer);
 });

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -1,9 +1,8 @@
 import _ from 'lodash';
-import { getRoot, types } from 'mobx-state-tree';
+import { _NotCustomized, types } from 'mobx-state-tree';
 
+import { GenericModelData } from '../types/mobx-types';
 import { generateDatumModel, generateNewMoments } from './utils';
-
-export const DataStore = types.model('DataStore', {});
 
 /*
 continuous --> normalized: value between 0-1, display: two decimal places
@@ -73,7 +72,7 @@ export function dataStoreFactory(
   name: string,
   rawDataSet: GenericDatum[],
   inferTypes: InferObject
-): unknown {
+): GenericModelData {
   const keysArray = getKeysArray(rawDataSet);
   const filledDataSet = populateNullData(rawDataSet, keysArray);
   const moments = calculateMoments(filledDataSet, inferTypes);
@@ -84,7 +83,7 @@ export function dataStoreFactory(
     generateDatumModel(keysArray, inferTypes, moments)
   );
   const genericDataset = types
-    .model('dataSet', {
+    .model(modelName, {
       data: types.array(datumStore)
     })
     .extend(self => {
@@ -103,5 +102,5 @@ export function dataStoreFactory(
       };
     });
 
-  return { modelName, genericDataset, moments };
+  return genericDataset;
 }

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { _NotCustomized, types } from 'mobx-state-tree';
 
-import { GenericModelData } from '../types/mobx-types';
+import { DataStoreInstanceType } from '../types/mobx-types';
 import { generateDatumModel, generateNewMoments } from './utils';
 
 /*
@@ -72,7 +72,7 @@ export function dataStoreFactory(
   name: string,
   rawDataSet: GenericDatum[],
   inferTypes: InferObject
-): GenericModelData {
+): DataStoreInstanceType {
   const keysArray = getKeysArray(rawDataSet);
   const filledDataSet = populateNullData(rawDataSet, keysArray);
   const moments = calculateMoments(filledDataSet, inferTypes);
@@ -102,5 +102,5 @@ export function dataStoreFactory(
       };
     });
 
-  return genericDataset;
+  return genericDataset.create({});
 }

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -1,5 +1,7 @@
+import _ from 'lodash';
 import { types } from 'mobx-state-tree';
-import { isCategorical, isContinous, isDatetime } from '../types/utils';
+
+import { generateNewMoments } from './utils';
 
 export const DataStore = types.model('DataStore', {});
 
@@ -8,8 +10,6 @@ continuous --> normalized: value between 0-1, display: two decimal places
 categorical --> one-hot label, display: = raw 
 date --> raw: unix, display: dd-mm-yyyy or given ISO format
 */
-// tslint:disable:no-if-statement
-// Fuck you tslint, watch me us those fucking if statements.
 
 const mapParams: MapTypeInfer = {
   categorical: { frequencies: {} },
@@ -17,55 +17,14 @@ const mapParams: MapTypeInfer = {
   date: { min: 0, max: 0 }
 };
 
-export const generateNewMoments = (
-  accumulator: MomentsObject,
-  datum: GenericDatum
-) => {
-  const entries = Object.entries(datum);
-
-  const newMoments: MomentsObject = entries.map(([key, value], index) => {
-    const variableMoments = accumulator[index];
-
-    if (isCategorical(variableMoments) && typeof value === 'string') {
-      const { frequencies } = variableMoments;
-      const newFrequencies = {
-        ...frequencies,
-        [key]: frequencies[key] ? frequencies[key] + 1 : 1
-      };
-      const newFrequencyMoments: NormalizingCategorical = {
-        frequencies: newFrequencies
-      };
-
-      return newFrequencyMoments;
-    } else if (isContinous(variableMoments) && typeof value === 'number') {
-      const { min, max, sum } = variableMoments;
-      const newContinousMoments: NormalizingContinuous = {
-        max: value && value > max ? value : max,
-        min: value && value < min ? value : min,
-        sum: sum + value
-      };
-
-      return newContinousMoments;
-    } else if (isDatetime(variableMoments) && typeof value === 'number') {
-      const { min, max } = variableMoments;
-      const newDatetimeMoments: NormalizingDatetime = {
-        max: value && value > max ? value : max,
-        min: value && value < min ? value : min
-      };
-      return newDatetimeMoments;
-    } else {
-      return variableMoments;
-    }
-  });
-  return newMoments;
-};
-
 export function generateParamsArrayFromInferObject(
   inferObject: InferObject
 ): MomentsObject {
-  return Object.values(inferObject).map(possibleType => {
-    return mapParams[possibleType];
-  });
+  return _.fromPairs(
+    _.toPairs(inferObject).map(([variable, possibleType]) => {
+      return [variable, mapParams[possibleType]];
+    })
+  );
 }
 
 export function getKeysArray(rawDataSet: GenericDatum[]): string[] {

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -13,8 +13,8 @@ date --> raw: unix, display: dd-mm-yyyy or given ISO format
 
 const mapParams: MapTypeInfer = {
   categorical: { frequencies: {} },
-  continuous: { min: 0, max: 0, sum: 0 },
-  date: { min: 0, max: 0 }
+  continuous: { min: null, max: null, sum: 0 },
+  date: { min: null, max: null }
 };
 
 export function generateParamsArrayFromInferObject(

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -21,7 +21,9 @@ export const generateNewMoments = (accumulator: MomentsObject) => (
 
   const newAccumulator = values.map((value, index) => {
     const variableMoments = accumulator[index];
-    const { min, max } = variableMoments;
+    switch(typeof variableMoments) {
+      case 
+    }
   });
   return;
 };

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -15,13 +15,36 @@ const mapParams: MapTypeInfer = {
 };
 
 export function generateParamsArrayFromInferArray(
-  inferArray: ReadonlyArray<InferType>
-): ReadonlyArray<
-  NormalizingContinuous | NormalizingCategorical | NormalizingDatetime
-> {
+  inferArray: InferType[]
+): Array<NormalizingContinuous | NormalizingCategorical | NormalizingDatetime> {
   return inferArray.map(possibleType => {
     return mapParams[possibleType];
   });
+}
+
+export function getKeysArray(rawDataSet: GenericDatum[]): string[] {
+  const keysSet = rawDataSet.reduce((accumulator: Set<string>, datum) => {
+    const keys = Object.keys(datum);
+    return new Set([...accumulator, ...keys]);
+  }, new Set<string>());
+
+  const keysArray = Array.from(keysSet);
+  return keysArray;
+}
+
+export function populateNullData(rawDataSet: GenericDatum[]): GenericDatum[] {
+  const keysArray = getKeysArray(rawDataSet);
+
+  const filledDataSet = rawDataSet.map(datum => {
+    const filledDatum: GenericDatum = keysArray.reduce(
+      (acc: GenericDatum, key) => {
+        return { ...acc, [key]: datum.hasOwnProperty(key) ? datum[key] : null };
+      },
+      {}
+    );
+    return filledDatum;
+  });
+  return filledDataSet;
 }
 
 export function dataStoreFactory(
@@ -29,26 +52,27 @@ export function dataStoreFactory(
   inferTypes: InferObject,
   name?: string
 ): unknown {
-  // const keysSet = rawDataSet.reduce((accumulator: Set<string>, datum) => {
-  //   const keys = Object.keys(datum);
-  //   return new Set([...accumulator, ...keys]);
-  // }, new Set<string>());
-
+  // This is done temporaraly in order to avoid tslint errors
   /* tslint:disable */
   console.log(rawDataSet, inferTypes, name);
   /* tslint:enable */
 
-  // const keysArray = Array.from(keysSet);
+  const keysSet = rawDataSet.reduce((accumulator: Set<string>, datum) => {
+    const keys = Object.keys(datum);
+    return new Set([...accumulator, ...keys]);
+  }, new Set<string>());
 
-  // const filledDataSet = rawDataSet.map(datum => {
-  //   const filledDatum: GenericDatum = keysArray.reduce(
-  //     (acc: GenericDatum, key) => {
-  //       return { ...acc, [key]: datum.hasOwnProperty(key) ? datum.key : null };
-  //     },
-  //     {}
-  //   );
-  //   return filledDatum;
-  // });
+  const keysArray = Array.from(keysSet);
+
+  const filledDataSet = rawDataSet.map(datum => {
+    const filledDatum: GenericDatum = keysArray.reduce(
+      (acc: GenericDatum, key) => {
+        return { ...acc, [key]: datum.hasOwnProperty(key) ? datum.key : null };
+      },
+      {}
+    );
+    return filledDatum;
+  });
 
   // const normalizingParameters: ReadonlyArray<
   //   NormalizingContinuous | NormalizingCategorical | NormalizingDatetime
@@ -62,5 +86,5 @@ export function dataStoreFactory(
   //   return types.frozen<GenericDatum>(filledDatum);
   // });
 
-  return {};
+  return filledDataSet;
 }

--- a/src/lib/datastore.ts
+++ b/src/lib/datastore.ts
@@ -14,10 +14,22 @@ const mapParams: MapTypeInfer = {
   date: { min: 0, max: 0 }
 };
 
-export function generateParamsArrayFromInferArray(
-  inferArray: InferType[]
+export const generateNewMoments = (accumulator: MomentsObject) => (
+  datum: GenericDatum
+): unknown => {
+  const values = Object.values(datum);
+
+  const newAccumulator = values.map((value, index) => {
+    const variableMoments = accumulator[index];
+    const { min, max } = variableMoments;
+  });
+  return;
+};
+
+export function generateParamsArrayFromInferObject(
+  inferObject: InferObject
 ): Array<NormalizingContinuous | NormalizingCategorical | NormalizingDatetime> {
-  return inferArray.map(possibleType => {
+  return Object.values(inferObject).map(possibleType => {
     return mapParams[possibleType];
   });
 }
@@ -32,9 +44,10 @@ export function getKeysArray(rawDataSet: GenericDatum[]): string[] {
   return keysArray;
 }
 
-export function populateNullData(rawDataSet: GenericDatum[]): GenericDatum[] {
-  const keysArray = getKeysArray(rawDataSet);
-
+export function populateNullData(
+  rawDataSet: GenericDatum[],
+  keysArray: string[]
+): GenericDatum[] {
   const filledDataSet = rawDataSet.map(datum => {
     const filledDatum: GenericDatum = keysArray.reduce(
       (acc: GenericDatum, key) => {
@@ -47,44 +60,35 @@ export function populateNullData(rawDataSet: GenericDatum[]): GenericDatum[] {
   return filledDataSet;
 }
 
+export function calculateMoments(
+  rawDataSet: GenericDatum[],
+  inferObject: InferObject
+): MomentsObject {
+  const inferedObject: MomentsObject = generateParamsArrayFromInferObject(
+    inferObject
+  );
+
+  const momentsObject: MomentsObject = rawDataSet.reduce(
+    (accumulator: MomentsObject, datum) => {
+      const entries = Object.entries(datum);
+
+      const h = entries.map((key, value) => {});
+
+      return { ...accumulator };
+    },
+    inferedObject
+  );
+
+  return momentsObject;
+}
+
 export function dataStoreFactory(
-  rawDataSet: GenericDataSet,
-  inferTypes: InferObject,
-  name?: string
+  rawDataSet: GenericDatum[]
+  // inferTypes: InferObject
+  // name?: string
 ): unknown {
-  // This is done temporaraly in order to avoid tslint errors
-  /* tslint:disable */
-  console.log(rawDataSet, inferTypes, name);
-  /* tslint:enable */
-
-  const keysSet = rawDataSet.reduce((accumulator: Set<string>, datum) => {
-    const keys = Object.keys(datum);
-    return new Set([...accumulator, ...keys]);
-  }, new Set<string>());
-
-  const keysArray = Array.from(keysSet);
-
-  const filledDataSet = rawDataSet.map(datum => {
-    const filledDatum: GenericDatum = keysArray.reduce(
-      (acc: GenericDatum, key) => {
-        return { ...acc, [key]: datum.hasOwnProperty(key) ? datum.key : null };
-      },
-      {}
-    );
-    return filledDatum;
-  });
-
-  // const normalizingParameters: ReadonlyArray<
-  //   NormalizingContinuous | NormalizingCategorical | NormalizingDatetime
-  // > = null;
-  // // filledDataSet.reduce((accumulator, datum) => {
-
-  // // },
-  // // generateParamsArrayFromInferArray(inferTypes));
-
-  // const frozenArray = filledDataSet.map(filledDatum => {
-  //   return types.frozen<GenericDatum>(filledDatum);
-  // });
+  const keysArray = getKeysArray(rawDataSet);
+  const filledDataSet = populateNullData(rawDataSet, keysArray);
 
   return filledDataSet;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,11 @@ import { isCategorical, isContinous, isDatetime } from '../types/utils';
 // tslint:disable:no-if-statement
 // Fuck you tslint, watch me us those fucking if statements.
 
+const updateMin = (value: number, min: number | null) =>
+  _.isNull(min) ? value : _.min([value, min]) || min;
+const updateMax = (value: number, max: number | null) =>
+  _.isNull(max) ? value : _.max([value, max]) || max;
+
 export const generateNewMoments = (
   accumulator: MomentsObject,
   datum: GenericDatum
@@ -18,7 +23,7 @@ export const generateNewMoments = (
       const { frequencies } = variableMoments;
       const newFrequencies = {
         ...frequencies,
-        [variable]: frequencies[variable] ? frequencies[variable] + 1 : 1
+        [value]: frequencies[value] ? frequencies[value] + 1 : 1
       };
       const newFrequencyMoments: NormalizingCategorical = {
         frequencies: newFrequencies
@@ -27,18 +32,26 @@ export const generateNewMoments = (
       return [variable, newFrequencyMoments];
     } else if (isContinous(variableMoments) && typeof value === 'number') {
       const { min, max, sum } = variableMoments;
+
+      const newMin = updateMin(value, min);
+      const newMax = updateMax(value, max);
+      const updatedSum = sum + value;
+
       const newContinousMoments: NormalizingContinuous = {
-        max: value && value > max ? value : max,
-        min: value && value < min ? value : min,
-        sum: sum + value
+        max: newMax,
+        min: newMin,
+        sum: updatedSum
       };
 
       return [variable, newContinousMoments];
     } else if (isDatetime(variableMoments) && typeof value === 'number') {
       const { min, max } = variableMoments;
+      const newMin = updateMin(value, min);
+      const newMax = updateMax(value, max);
+
       const newDatetimeMoments: NormalizingDatetime = {
-        max: value && value > max ? value : max,
-        min: value && value < min ? value : min
+        max: newMax,
+        min: newMin
       };
       return [variable, newDatetimeMoments];
     } else {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { ISimpleType, types } from 'mobx-state-tree';
 
 import { isCategorical, isContinous, isDatetime } from '../types/utils';
 
@@ -63,3 +64,31 @@ export const generateNewMoments = (
 
   return newMoments;
 };
+
+export function generateDatumModel(
+  datumKeys: string[],
+  instanceObj: InferObject,
+  moments: MomentsObject
+): { [variable: string]: ISimpleType<string | number> } {
+  const model = datumKeys.map(variable => {
+    const instance = instanceObj[variable];
+    switch (instance) {
+      case 'continuous':
+        return [variable, types.number];
+      case 'date':
+        return [variable, types.number];
+      case 'categorical':
+        const moment = moments[variable];
+        const uniqueKeys = isCategorical(moment)
+          ? _.keys(moment.frequencies)
+          : [];
+        return [variable, types.enumeration(uniqueKeys)];
+    }
+  });
+
+  const storeObj: {
+    [variable: string]: ISimpleType<number | string>;
+  } = _.fromPairs(model);
+
+  return storeObj;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { ISimpleType, types } from 'mobx-state-tree';
+import { IMaybeNull, ISimpleType, types } from 'mobx-state-tree';
 
 import { isCategorical, isContinous, isDatetime } from '../types/utils';
 
@@ -69,25 +69,25 @@ export function generateDatumModel(
   datumKeys: string[],
   instanceObj: InferObject,
   moments: MomentsObject
-): { [variable: string]: ISimpleType<string | number> } {
+): { [variable: string]: IMaybeNull<ISimpleType<number | string | boolean>> } {
   const model = datumKeys.map(variable => {
     const instance = instanceObj[variable];
     switch (instance) {
       case 'continuous':
-        return [variable, types.number];
+        return [variable, types.maybeNull(types.number)];
       case 'date':
-        return [variable, types.number];
+        return [variable, types.maybeNull(types.number)];
       case 'categorical':
         const moment = moments[variable];
         const uniqueKeys = isCategorical(moment)
           ? _.keys(moment.frequencies)
           : [];
-        return [variable, types.enumeration(uniqueKeys)];
+        return [variable, types.maybeNull(types.enumeration(uniqueKeys))];
     }
   });
 
   const storeObj: {
-    [variable: string]: ISimpleType<number | string>;
+    [variable: string]: IMaybeNull<ISimpleType<number | string | boolean>>;
   } = _.fromPairs(model);
 
   return storeObj;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+
+import { isCategorical, isContinous, isDatetime } from '../types/utils';
+
+// tslint:disable:no-if-statement
+// Fuck you tslint, watch me us those fucking if statements.
+
+export const generateNewMoments = (
+  accumulator: MomentsObject,
+  datum: GenericDatum
+) => {
+  const entries = _.toPairs(datum);
+
+  const newMomentsEntries = entries.map(([variable, value]) => {
+    const variableMoments = accumulator[variable];
+
+    if (isCategorical(variableMoments) && typeof value === 'string') {
+      const { frequencies } = variableMoments;
+      const newFrequencies = {
+        ...frequencies,
+        [variable]: frequencies[variable] ? frequencies[variable] + 1 : 1
+      };
+      const newFrequencyMoments: NormalizingCategorical = {
+        frequencies: newFrequencies
+      };
+
+      return [variable, newFrequencyMoments];
+    } else if (isContinous(variableMoments) && typeof value === 'number') {
+      const { min, max, sum } = variableMoments;
+      const newContinousMoments: NormalizingContinuous = {
+        max: value && value > max ? value : max,
+        min: value && value < min ? value : min,
+        sum: sum + value
+      };
+
+      return [variable, newContinousMoments];
+    } else if (isDatetime(variableMoments) && typeof value === 'number') {
+      const { min, max } = variableMoments;
+      const newDatetimeMoments: NormalizingDatetime = {
+        max: value && value > max ? value : max,
+        min: value && value < min ? value : min
+      };
+      return [variable, newDatetimeMoments];
+    } else {
+      return [variable, variableMoments];
+    }
+  });
+
+  const newMoments: MomentsObject = _.fromPairs(newMomentsEntries);
+
+  return newMoments;
+};

--- a/src/types/mobx-types.ts
+++ b/src/types/mobx-types.ts
@@ -1,0 +1,25 @@
+import {
+  _NotCustomized,
+  IArrayType,
+  IModelType,
+  ISimpleType,
+  ModelPropertiesDeclarationToProperties
+} from 'mobx-state-tree';
+
+export type GenericModelData = IModelType<
+  ModelPropertiesDeclarationToProperties<{
+    data: IArrayType<
+      IModelType<
+        ModelPropertiesDeclarationToProperties<{
+          [variable: string]: ISimpleType<string | number>;
+        }>,
+        {},
+        _NotCustomized,
+        _NotCustomized
+      >
+    >;
+  }>,
+  {},
+  _NotCustomized,
+  _NotCustomized
+>;

--- a/src/types/mobx-types.ts
+++ b/src/types/mobx-types.ts
@@ -3,10 +3,11 @@ import {
   IArrayType,
   IModelType,
   ISimpleType,
+  ModelInstanceType,
   ModelPropertiesDeclarationToProperties
 } from 'mobx-state-tree';
 
-export type GenericModelData = IModelType<
+export type DataStoreInstanceType = ModelInstanceType<
   ModelPropertiesDeclarationToProperties<{
     data: IArrayType<
       IModelType<

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -9,8 +9,6 @@ interface GenericDatum {
     | null;
 }
 
-type GenericDataSet = ReadonlyArray<GenericDatum>;
-
 interface NormalizingContinuous {
   readonly mean: number;
   readonly min: number;
@@ -38,4 +36,10 @@ type InferType = keyof MapTypeInfer;
 
 type MapSchema<T extends InferType> = MapTypeInfer[T];
 
-interface InferObject { readonly [key: string]: InferType }
+interface InferObject {
+  readonly [key: string]: InferType;
+}
+
+type MomentsObject = Array<
+  NormalizingContinuous | NormalizingCategorical | NormalizingDatetime
+>;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -41,4 +41,6 @@ interface InferObject {
   readonly [key: string]: InferType;
 }
 
-type MomentsObject = MomentsType[];
+type MomentsObject = {
+  readonly [variable: string]: MomentsType
+};

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,3 +1,5 @@
+type ValueOf<T> = T[keyof T];
+
 interface GenericDatum {
   readonly [key: string]:
     | number
@@ -10,7 +12,7 @@ interface GenericDatum {
 }
 
 interface NormalizingContinuous {
-  readonly mean: number;
+  readonly sum: number;
   readonly min: number;
   readonly max: number;
 }
@@ -21,9 +23,7 @@ interface NormalizingDatetime {
 }
 
 interface NormalizingCategorical {
-  readonly frequencies: ReadonlyArray<
-    ReadonlyArray<{ readonly [variable: string]: number }>
-  >;
+  readonly frequencies: { readonly [variable: string]: number };
 }
 
 interface MapTypeInfer {
@@ -33,6 +33,7 @@ interface MapTypeInfer {
 }
 
 type InferType = keyof MapTypeInfer;
+type MomentsType = ValueOf<MapTypeInfer>;
 
 type MapSchema<T extends InferType> = MapTypeInfer[T];
 
@@ -40,6 +41,4 @@ interface InferObject {
   readonly [key: string]: InferType;
 }
 
-type MomentsObject = Array<
-  NormalizingContinuous | NormalizingCategorical | NormalizingDatetime
->;
+type MomentsObject = MomentsType[];

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -13,17 +13,17 @@ interface GenericDatum {
 
 interface NormalizingContinuous {
   readonly sum: number;
-  readonly min: number;
-  readonly max: number;
+  readonly min: number | null;
+  readonly max: number | null;
 }
 
 interface NormalizingDatetime {
-  readonly min: number;
-  readonly max: number;
+  readonly min: number | null;
+  readonly max: number | null;
 }
 
 interface NormalizingCategorical {
-  readonly frequencies: { readonly [variable: string]: number };
+  readonly frequencies: { readonly [instance: string]: number };
 }
 
 interface MapTypeInfer {
@@ -41,6 +41,6 @@ interface InferObject {
   readonly [key: string]: InferType;
 }
 
-type MomentsObject = {
-  readonly [variable: string]: MomentsType
-};
+interface MomentsObject {
+  readonly [variable: string]: MomentsType;
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,14 +1,7 @@
 type ValueOf<T> = T[keyof T];
 
 interface GenericDatum {
-  readonly [key: string]:
-    | number
-    | string
-    | boolean
-    | ReadonlyArray<number>
-    | ReadonlyArray<string>
-    | GenericDatum
-    | null;
+  readonly [key: string]: number | string | boolean | null;
 }
 
 interface NormalizingContinuous {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,8 +1,24 @@
 // tslint:disable:no-if-statement
 
-export function whichMoment(
-  moment: NormalizingContinuous | NormalizingDatetime | NormalizingCategorical
-) {
-  if (moment) {
-  }
+function hasMultipleProperties(
+  obj: { [key: string]: unknown },
+  properties: string[]
+): boolean {
+  return properties.every(p => obj.hasOwnProperty(p));
 }
+
+export const isContinous = (
+  moment: MomentsType
+): moment is NormalizingContinuous =>
+  hasMultipleProperties(moment, ['min', 'max', 'mean']);
+
+export const isDatetime = (
+  moment: MomentsType
+): moment is NormalizingDatetime =>
+  hasMultipleProperties(moment, ['min', 'max']) &&
+  !moment.hasOwnProperty('mean');
+
+export const isCategorical = (
+  moment: MomentsType
+): moment is NormalizingCategorical =>
+  hasMultipleProperties(moment, ['frequencies']);

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,8 @@
+// tslint:disable:no-if-statement
+
+export function whichMoment(
+  moment: NormalizingContinuous | NormalizingDatetime | NormalizingCategorical
+) {
+  if (moment) {
+  }
+}

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-if-statement
 
-function hasMultipleProperties(
+export function hasMultipleProperties(
   obj: { [key: string]: unknown },
   properties: string[]
 ): boolean {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -10,13 +10,13 @@ function hasMultipleProperties(
 export const isContinous = (
   moment: MomentsType
 ): moment is NormalizingContinuous =>
-  hasMultipleProperties(moment, ['min', 'max', 'mean']);
+  hasMultipleProperties(moment, ['min', 'max', 'sum']);
 
 export const isDatetime = (
   moment: MomentsType
 ): moment is NormalizingDatetime =>
   hasMultipleProperties(moment, ['min', 'max']) &&
-  !moment.hasOwnProperty('mean');
+  !moment.hasOwnProperty('sum');
 
 export const isCategorical = (
   moment: MomentsType

--- a/tslint.json
+++ b/tslint.json
@@ -13,8 +13,8 @@
     "typedef": [true, "call-signature"],
 
     // Immutability rules
-    "readonly-keyword": true,
-    "readonly-array": true,
+    "readonly-keyword": false,
+    "readonly-array": false,
     "no-let": true,
     "no-object-mutation": true,
     "no-delete": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,7 +459,7 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
   integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
-"@types/lodash@^4.14.110":
+"@types/lodash@^4.14.110", "@types/lodash@^4.14.122":
   version "4.14.122"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.122.tgz#3e31394c38cf1e5949fb54c1192cbc406f152c6c"
   integrity sha512-9IdED8wU93ty8gP06ninox+42SBSJHp2IAamsSYMUY76mshRTeUsid/gtbl8ovnOwy8im41ib4cxTiIYMXGKew==


### PR DESCRIPTION
Initial setup of the dataStore factory! Now the function can be called on a dataset with an array of inferred type and it will generate a dataStore with all the getters you need (for now). It is just the beginning but it is better to keep PRs short. The usage is as follows:

```
const FIRST_SAMPLE_DATA: GenericDatum[] = [
  { a: 3, b: 'mamma' },
  { a: 2, b: 'papà', c: 2 }
];
const INSTANCE_TYPES: InferObject = {
  a: 'continuous',
  b: 'categorical',
  c: 'continuous'
};
```
and then `dataStoreFactory('Fugaro', FIRST_SAMPLE_DATA, INSTANCE_TYPES)`